### PR TITLE
Support Poly retry policy and basic error handling

### DIFF
--- a/BscScanner.Tests/AccountsApiTests.cs
+++ b/BscScanner.Tests/AccountsApiTests.cs
@@ -8,20 +8,24 @@ namespace BscScanner.Tests {
 
         [Test]
         public async Task RunSingleBalanceTest() {
-            var balance = await BscScanClient.GetBnbBalanceSingleAsync("0x29980bc85603c8b2a335e5375b57634a1fcef64b");
+            var balance = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBnbBalanceSingleAsync("0x29980bc85603c8b2a335e5375b57634a1fcef64b")
+            );
 
             Assert.AreEqual(balance, 0f);
         }
 
         [Test]
         public async Task RunMultipleBalanceTest() {
-            var balance = await BscScanClient.GetBnbBalanceMultipleAsync(new[] {
-                "0x0000000000000000000000000000000000001004",
-                "0x59784ccC71205eF6A292F973e44f46CdC1f58306",
-                "0x4430b3230294d12c6ab2aac5c2cd68e80b16b581",
-                "0x0caac5b6074b04226d9731ad4868f9d26971b2a8",
-                "0xa56b49db164d37be2f5df2830db0c666380cea66"
-            });
+            var balance = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBnbBalanceMultipleAsync(new[] {
+                    "0x0000000000000000000000000000000000001004",
+                    "0x59784ccC71205eF6A292F973e44f46CdC1f58306",
+                    "0x4430b3230294d12c6ab2aac5c2cd68e80b16b581",
+                    "0x0caac5b6074b04226d9731ad4868f9d26971b2a8",
+                    "0xa56b49db164d37be2f5df2830db0c666380cea66"
+                })
+            );
 
             foreach ( var bal in balance ) {
                 Assert.NotNull(bal);
@@ -30,7 +34,9 @@ namespace BscScanner.Tests {
 
         [Test]
         public async Task RunGetTransactionsByAddress() {
-            var result = await BscScanClient.GetTransactionsByAddress("0x59784ccC71205eF6A292F973e44f46CdC1f58306");
+            var result = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetTransactionsByAddress("0x59784ccC71205eF6A292F973e44f46CdC1f58306")
+            );
 
             foreach ( var r in result ) {
                 Assert.NotNull(r);
@@ -39,9 +45,9 @@ namespace BscScanner.Tests {
 
         [Test]
         public async Task RunGetTransactionsByHash() {
-            var result =
-                await BscScanClient.GetTransactionsByHash(
-                    "0x4d74a6fc84d57f18b8e1dfa07ee517c4feb296d16a8353ee41adc03669982028");
+            var result = await RetryPolicy.BscScan.ExecuteAsync(() => RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetTransactionsByHash("0x4d74a6fc84d57f18b8e1dfa07ee517c4feb296d16a8353ee41adc03669982028"))
+            );
 
             foreach ( var r in result ) {
                 Assert.NotNull(r);
@@ -50,7 +56,9 @@ namespace BscScanner.Tests {
 
         [Test]
         public async Task RunGetTransactionsByBlockRange() {
-            var result = await BscScanClient.GetTransactionsByBlockRange(1, 100000);
+            var result = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetTransactionsByBlockRange(1, 100000)
+            );
 
             foreach ( var r in result ) {
                 Assert.NotNull(r);
@@ -59,8 +67,9 @@ namespace BscScanner.Tests {
 
         [Test]
         public async Task RunGetBep20TokenTransfersByAddress() {
-            var result =
-                await BscScanClient.GetBep20TokenTransfersByAddress("0x7bb89460599dbf32ee3aa50798bbceae2a5f7f6a");
+            var result = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBep20TokenTransfersByAddress("0x7bb89460599dbf32ee3aa50798bbceae2a5f7f6a")
+            );
 
             foreach ( var r in result ) {
                 Assert.NotNull(r);
@@ -70,8 +79,9 @@ namespace BscScanner.Tests {
         [Test]
         public async Task RunGetBep20TokenTransfersByContractAddress()
         {
-            var result =
-                await BscScanClient.GetBep20TokenTransferByContractAddress("0x7bb89460599dbf32ee3aa50798bbceae2a5f7f6a");
+            var result = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBep20TokenTransferByContractAddress("0x7bb89460599dbf32ee3aa50798bbceae2a5f7f6a")
+            );
 
             foreach (var r in result)
             {
@@ -81,8 +91,9 @@ namespace BscScanner.Tests {
 
         [Test]
         public async Task RunGetErc721TokenTransfersByAddress() {
-            var result =
-                await BscScanClient.GetErc721TokenTransfersByAddress("0xcd4ee0a77e09afa8d5a6518f7cf8539bef684e6c");
+            var result = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetErc721TokenTransfersByAddress("0xcd4ee0a77e09afa8d5a6518f7cf8539bef684e6c")
+            );
 
             foreach ( var r in result ) {
                 Assert.NotNull(r);
@@ -92,8 +103,9 @@ namespace BscScanner.Tests {
         [Test]
         public async Task RunGetErc721TokenTransfersByContractAddress()
         {
-            var result =
-                await BscScanClient.GetErc721TokenTransferByContractAddress("0xc9849e6fdb743d08faee3e34dd2d1bc69ea11a51");
+            var result = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetErc721TokenTransferByContractAddress("0xc9849e6fdb743d08faee3e34dd2d1bc69ea11a51")
+            );
 
             foreach (var r in result)
             {
@@ -103,7 +115,9 @@ namespace BscScanner.Tests {
 
         [Test]
         public async Task RunGetBlocksValidatedByAddress() {
-            var result = await BscScanClient.GetBlocksValidatedByAddress("0x78f3adfc719c99674c072166708589033e2d9afe");
+            var result = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBlocksValidatedByAddress("0x78f3adfc719c99674c072166708589033e2d9afe")
+            );
 
             foreach ( var r in result ) {
                 Assert.NotNull(r);

--- a/BscScanner.Tests/BlocksApiTests.cs
+++ b/BscScanner.Tests/BlocksApiTests.cs
@@ -9,7 +9,9 @@ namespace BscScanner.Tests {
 
         [Test]
         public async Task RunGetBlockRewardByBlock() {
-            var blockReward = await BscScanClient.GetBlockRewardByBlock(2150000);
+            var blockReward = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBlockRewardByBlock(2150000)
+            );
 
             Assert.AreEqual("2150000",blockReward.BlockNumber);
             Assert.AreEqual("1605122780", blockReward.TimeStamp);
@@ -17,29 +19,36 @@ namespace BscScanner.Tests {
         
         [Test]
         public async Task RunGetBlockCountdownByBlockPassed() {
-            var blockReward = await BscScanClient.GetBlockCountdownByBlock(8000000);
+            var blockReward = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBlockCountdownByBlock(8000000)
+            );
 
             Assert.AreEqual(null, blockReward);
         }
         
         [Test]
         public async Task RunGetBlockCountdownByBlockUpcoming() {
-            var blockReward = await BscScanClient.GetBlockCountdownByBlock(80000000);
+            var blockReward = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBlockCountdownByBlock(80000000)
+            );
 
             Assert.AreNotEqual(null, blockReward);
         }
 
         [Test]
         public async Task RunGetBlockNumberByTimestampLong() {
-            var blockReward = await BscScanClient.GetBlockNumberByTimestamp(1624569213);
+            var blockReward = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBlockNumberByTimestamp(1624569213)
+            );
 
             Assert.AreEqual(8586272, blockReward);
         }
         
         [Test]
         public async Task RunGetBlockNumberByTimestampDateTime() {
-            var blockReward =
-                await BscScanClient.GetBlockNumberByTimestamp(new DateTime(2021, 06, 24, 9+12, 13, 33, DateTimeKind.Utc));
+            var blockReward = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBlockNumberByTimestamp(new DateTime(2021, 06, 24, 9+12, 13, 33, DateTimeKind.Utc))
+            );
 
             Assert.AreEqual(8586272, blockReward);
         }

--- a/BscScanner.Tests/BscScanner.Tests.csproj
+++ b/BscScanner.Tests/BscScanner.Tests.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.2" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
       <PackageReference Include="NUnit" Version="3.13.2" />

--- a/BscScanner.Tests/BscScanner.Tests.csproj
+++ b/BscScanner.Tests/BscScanner.Tests.csproj
@@ -6,9 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
       <PackageReference Include="NUnit" Version="3.13.2" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/BscScanner.Tests/ContractApiTests.cs
+++ b/BscScanner.Tests/ContractApiTests.cs
@@ -8,14 +8,18 @@ namespace BscScanner.Tests {
 
         [Test]
         public async Task RunGetAbiFromSource() {
-            var balance = await BscScanClient.GetAbiFromSourceAddress("0x0000000000000000000000000000000000001004");
+            var balance = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetAbiFromSourceAddress("0x0000000000000000000000000000000000001004")
+            );
 
             Assert.IsNotEmpty(balance);
         }
         
         [Test]
         public async Task RunGetSourceCodeFromSource() {
-            var balance = await BscScanClient.GetSourceCodeFromSourceAddress("0x0000000000000000000000000000000000001004");
+            var balance = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetSourceCodeFromSourceAddress("0x0000000000000000000000000000000000001004")
+            );
 
             Assert.IsNotEmpty(balance);
         }

--- a/BscScanner.Tests/ParityProxyApiTests.cs
+++ b/BscScanner.Tests/ParityProxyApiTests.cs
@@ -9,7 +9,9 @@ namespace BscScanner.Tests {
         
         [Test]
         public async Task RunGetLatestBlock() {
-            Assert.DoesNotThrowAsync(async () => await BscScanClient.GetLatestBlock());
+            Assert.DoesNotThrowAsync(async () => await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetLatestBlock())
+            );
         }
     }
 }

--- a/BscScanner.Tests/RetryPolicy.cs
+++ b/BscScanner.Tests/RetryPolicy.cs
@@ -1,0 +1,16 @@
+﻿using Polly;
+using Polly.Retry;
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace BscScanner.Tests
+{
+    internal class RetryPolicy
+    {
+        //Free plan = Limit 5 calls per second
+        public static AsyncRetryPolicy BscScan = Policy
+            .Handle<HttpRequestException>(e => e.StatusCode == HttpStatusCode.TooManyRequests)
+            .WaitAndRetryAsync(5, attempt => TimeSpan.FromSeconds(1));
+    }
+}

--- a/BscScanner.Tests/StatsApiTests.cs
+++ b/BscScanner.Tests/StatsApiTests.cs
@@ -9,21 +9,27 @@ namespace BscScanner.Tests {
         
         [Test]
         public async Task RunGetBnbTotalSupply() {
-            var amount = await BscScanClient.GetBnbTotalSupply();
+            var amount = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBnbTotalSupply()
+            );
             
             Assert.NotZero(amount); 
         }
         
         [Test]
         public async Task RunGetBscValidators() {
-            var amount = await BscScanClient.GetBscValidators();
+            var amount = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBscValidators()
+            );
             
             Assert.NotZero(amount.Count()); 
         }
         
         [Test]
         public async Task RunGetBnbLastPrice() {
-            var amount = await BscScanClient.GetBnbLastPrice();
+            var amount = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetBnbLastPrice()
+            );
             
             Assert.IsNotEmpty(amount.EthBtc);
             Assert.IsNotEmpty(amount.EthUsd);

--- a/BscScanner.Tests/TokenApiTests.cs
+++ b/BscScanner.Tests/TokenApiTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Numerics;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace BscScanner.Tests {
@@ -12,7 +10,7 @@ namespace BscScanner.Tests {
         public async Task RunGetTokenTotalSupply() {
             var supply = await BscScanClient.GetTokenTotalSupply("0xe9e7cea3dedca5984780bafc599bd69add087d56");
             
-            Assert.AreEqual(double.Parse("4200999999996203280118545563"), supply);
+            Assert.AreEqual(double.Parse("4850999388629409465655005581"), supply);
         }
         
         [Test]

--- a/BscScanner.Tests/TokenApiTests.cs
+++ b/BscScanner.Tests/TokenApiTests.cs
@@ -8,25 +8,32 @@ namespace BscScanner.Tests {
         
         [Test]
         public async Task RunGetTokenTotalSupply() {
-            var supply = await BscScanClient.GetTokenTotalSupply("0xe9e7cea3dedca5984780bafc599bd69add087d56");
+            var supply = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetTokenTotalSupply("0xe9e7cea3dedca5984780bafc599bd69add087d56")
+            );
             
             Assert.AreEqual(double.Parse("4850999388629409465655005581"), supply);
         }
         
         [Test]
         public async Task RunGetTokenCirculatingSupply() {
-            Assert.DoesNotThrowAsync(async () => await BscScanClient.GetTokenCirculatingSupply("0xe9e7cea3dedca5984780bafc599bd69add087d56"));
+            Assert.DoesNotThrowAsync(async () => await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetTokenCirculatingSupply("0xe9e7cea3dedca5984780bafc599bd69add087d56"))
+            );
         }
         
         [Test]
         public async Task RunGetAccountBalanceByContractAddressNull() {
-            Assert.CatchAsync(async () =>
-                await BscScanClient.GetAccountBalanceByContractAddress("notatoken", "notanaddress"));
+            Assert.CatchAsync(async () => await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetAccountBalanceByContractAddress("notatoken", "notanaddress"))
+            );
         }
         
         [Test]
         public async Task RunGetAccountBalanceByContractAddressValid() {
-            var amount = await BscScanClient.GetAccountBalanceByContractAddress("0xc6cb12df4520b7bf83f64c79c585b8462e18b6aa", "0x59784ccC71205eF6A292F973e44f46CdC1f58306");
+            var amount = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetAccountBalanceByContractAddress("0xc6cb12df4520b7bf83f64c79c585b8462e18b6aa", "0x59784ccC71205eF6A292F973e44f46CdC1f58306")
+            );
             
             Assert.NotZero(amount);
         }

--- a/BscScanner.Tests/TransactionApiTests.cs
+++ b/BscScanner.Tests/TransactionApiTests.cs
@@ -8,10 +8,11 @@ namespace BscScanner.Tests {
         private static readonly IBscScanClient BscScanClient = new BscScanClient("7SYTNQ2B5SS7GR4WATVTFXP52BWSUK5PUJ");
 
         [Test]
-        public async Task RunGetAbiFromSource() {
-            var balance = await BscScanClient.GetTransactionReceiptStatus("0xe9975702518c79caf81d5da65dea689dcac701fcdd063f848d4f03c85392fd00");
-
-            Assert.AreEqual(balance, TxStatus.Pass);
+        public async Task RunGetTransactionReceiptStatus() {
+            var balance = await RetryPolicy.BscScan.ExecuteAsync(() => 
+                BscScanClient.GetTransactionReceiptStatus("0xe9975702518c79caf81d5da65dea689dcac701fcdd063f848d4f03c85392fd00")
+            );
+            Assert.AreEqual(balance, BscTxStatus.Pass);
         }
         
     }

--- a/BscScanner/BscScanner.csproj
+++ b/BscScanner/BscScanner.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <Optimize>true</Optimize>
+      <!--<Optimize>true</Optimize>-->
     </PropertyGroup>
 
     <ItemGroup>

--- a/BscScanner/Data/BscAbiSchema.cs
+++ b/BscScanner/Data/BscAbiSchema.cs
@@ -1,10 +1,8 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscAbiSchema {
-        [JsonProperty("status")] public string Status { get; private set; }
-        [JsonProperty("message")] public string Message { get; private set; }
+    internal class BscAbiSchema : BscResult {
+       
         [JsonProperty("result")] public string Result { get; private set; }
     }
 }

--- a/BscScanner/Data/BscBalance.cs
+++ b/BscScanner/Data/BscBalance.cs
@@ -1,0 +1,9 @@
+﻿using Newtonsoft.Json;
+
+namespace BscScanner.Data
+{
+    public class BscBalance {
+        [JsonProperty("account")] public string Account { get; set; }
+        [JsonProperty("balance")] public string Balance { get; set; }
+    }
+}

--- a/BscScanner/Data/BscBalanceMultipleSchema.cs
+++ b/BscScanner/Data/BscBalanceMultipleSchema.cs
@@ -2,14 +2,8 @@
 using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscBalanceMultipleSchema {
-        [JsonProperty("status")] public string Status { get; set; }
-        [JsonProperty("message")] public string Message { get; set; }
+    internal class BscBalanceMultipleSchema : BscResult {
+       
         [JsonProperty("result")] public List<BscBalance> Balances { get; set; }
-    }
-
-    public class BscBalance {
-        [JsonProperty("account")] public string Account { get; set; }
-        [JsonProperty("balance")] public string Balance { get; set; }
     }
 }

--- a/BscScanner/Data/BscBalanceSingleSchema.cs
+++ b/BscScanner/Data/BscBalanceSingleSchema.cs
@@ -1,9 +1,7 @@
 ﻿using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscBalanceSingleSchema {
-        [JsonProperty("status")] public string Status { get; private set; }
-        [JsonProperty("message")] public string Message { get; private set; }
+    internal class BscBalanceSingleSchema : BscResult {       
         [JsonProperty("result")] public string Result { get; private set; }
     }
 }

--- a/BscScanner/Data/BscBlockByTime.cs
+++ b/BscScanner/Data/BscBlockByTime.cs
@@ -1,9 +1,0 @@
-﻿using Newtonsoft.Json;
-
-namespace BscScanner.Data {
-    internal class BscBlockByTime {
-        [JsonProperty("status")] public string Status { get; private set; }
-        [JsonProperty("message")] public string Message { get; private set; }
-        [JsonProperty("result")] public string Result { get; private set; }
-    }
-}

--- a/BscScanner/Data/BscBlockByTimeSchema.cs
+++ b/BscScanner/Data/BscBlockByTimeSchema.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscTokenCirculatingSupplySchema : BscResult {
+    internal class BscBlockByTimeSchema : BscResult {
         [JsonProperty("result")] public string Result { get; private set; }
     }
 }

--- a/BscScanner/Data/BscBlockCountdownSchema.cs
+++ b/BscScanner/Data/BscBlockCountdownSchema.cs
@@ -1,9 +1,7 @@
 ﻿using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscBlockCountdownSchema {
-        [JsonProperty("status")] public string Status { get; set; }
-        [JsonProperty("message")] public string Message { get; set; }
+    internal class BscBlockCountdownSchema : BscResult {
         [JsonProperty("result")] public BscBlockCountdown Result { get; set; }
     }
 }

--- a/BscScanner/Data/BscBlockRewardSchema.cs
+++ b/BscScanner/Data/BscBlockRewardSchema.cs
@@ -1,10 +1,8 @@
 ﻿using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscBlockRewardSchema {
+    internal class BscBlockRewardSchema : BscResult {
         
-        [JsonProperty("status")] public string Status { get; set; }
-        [JsonProperty("message")] public string Message { get; set; }
         [JsonProperty("result")] public BscBlockReward Result { get; set; }
         
     }

--- a/BscScanner/Data/BscBlockScheme.cs
+++ b/BscScanner/Data/BscBlockScheme.cs
@@ -2,9 +2,7 @@
 using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscBlockScheme {
-        [JsonProperty("status")] public string Status { get; private set; }
-        [JsonProperty("message")] public string Message { get; private set; }
+    internal class BscBlockScheme : BscResult {
         [JsonProperty("result")] public IEnumerable<BscBlock> Result { get; private set; }
     }
 }

--- a/BscScanner/Data/BscBnbLastPriceSchema.cs
+++ b/BscScanner/Data/BscBnbLastPriceSchema.cs
@@ -2,9 +2,7 @@
 using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscBnbLastPriceSchema {
-        [JsonProperty("status")] public string Status { get; private set; }
-        [JsonProperty("message")] public string Message { get; private set; }
+    internal class BscBnbLastPriceSchema : BscResult {
         [JsonProperty("result")] public BscBnbPrice Result { get; private set; }
     }
 }

--- a/BscScanner/Data/BscBnbTotalSupplySchema.cs
+++ b/BscScanner/Data/BscBnbTotalSupplySchema.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscTokenCirculatingSupplySchema : BscResult {
+    internal class BscBnbTotalSupplySchema : BscResult {
         [JsonProperty("result")] public string Result { get; private set; }
     }
 }

--- a/BscScanner/Data/BscError.cs
+++ b/BscScanner/Data/BscError.cs
@@ -1,0 +1,9 @@
+﻿using Newtonsoft.Json;
+
+namespace BscScanner.Data
+{
+    internal class BscError : BscResult
+    {
+        [JsonProperty("result")] public string ErrorMessage { get; private set; }
+    }
+}

--- a/BscScanner/Data/BscLatestBlockSchema.cs
+++ b/BscScanner/Data/BscLatestBlockSchema.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    public class BscLatestBlock {
+    internal class BscLatestBlockSchema : BscResult {
         [JsonProperty("jsonrpc")] public string JsonRpc { get; set; }
         [JsonProperty("id")] public int Id { get; set; }
         [JsonProperty("result")] public string Result { get; set; }

--- a/BscScanner/Data/BscResult.cs
+++ b/BscScanner/Data/BscResult.cs
@@ -1,9 +1,10 @@
 ﻿using Newtonsoft.Json;
 
-namespace BscScanner.Data {
-    internal class BscBnbTotalSupply {
+namespace BscScanner.Data
+{
+    internal abstract class BscResult : IBscResult
+    {
         [JsonProperty("status")] public string Status { get; private set; }
         [JsonProperty("message")] public string Message { get; private set; }
-        [JsonProperty("result")] public string Result { get; private set; }
     }
 }

--- a/BscScanner/Data/BscSourceCodeSchema.cs
+++ b/BscScanner/Data/BscSourceCodeSchema.cs
@@ -2,9 +2,7 @@
 using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    public class BscSourceCodeSchema {
-        [JsonProperty("status")] public string Status { get; private set; }
-        [JsonProperty("message")] public string Message { get; private set; }
+    internal class BscSourceCodeSchema : BscResult {
         [JsonProperty("result")] public IEnumerable<BscContract> Result { get; private set; }
     }
 }

--- a/BscScanner/Data/BscTokenBalanceForContractAddressSchema.cs
+++ b/BscScanner/Data/BscTokenBalanceForContractAddressSchema.cs
@@ -1,5 +1,0 @@
-﻿namespace BscScanner.Data {
-    internal class BscTokenBalanceForContractAddressSchema {
-        
-    }
-}

--- a/BscScanner/Data/BscTokenTotalSupplySchema.cs
+++ b/BscScanner/Data/BscTokenTotalSupplySchema.cs
@@ -1,9 +1,7 @@
 ﻿using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    public class BscTokenTotalSupplySchema {
-        [JsonProperty("status")] public string Status { get; private set; }
-        [JsonProperty("message")] public string Message { get; private set; }
+    internal class BscTokenTotalSupplySchema : BscResult {
         [JsonProperty("result")] public string Result { get; private set; }
     }
 }

--- a/BscScanner/Data/BscTransactionSchema.cs
+++ b/BscScanner/Data/BscTransactionSchema.cs
@@ -2,9 +2,8 @@
 using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscTransactionSchema {
-        [JsonProperty("status")] public string Status { get; private set; }
-        [JsonProperty("message")] public string Message { get; private set; }
+    internal class BscTransactionSchema : BscResult {
+        
         [JsonProperty("result")] public List<BscTransaction> Result { get; private set; }
     }
 }

--- a/BscScanner/Data/BscTxReceipt.cs
+++ b/BscScanner/Data/BscTxReceipt.cs
@@ -1,0 +1,9 @@
+﻿using Newtonsoft.Json;
+
+namespace BscScanner.Data
+{
+    internal class BscTxReceipt
+    {
+        [JsonProperty("result")] public string Result { get; set; }
+    }
+}

--- a/BscScanner/Data/BscTxReceiptSchema.cs
+++ b/BscScanner/Data/BscTxReceiptSchema.cs
@@ -1,18 +1,7 @@
 ﻿using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscTxReceiptSchema {
-        [JsonProperty("status")] public string Status { get; set; }
-        [JsonProperty("message")] public string Message { get; set; }
-        [JsonProperty("result")] public TxReceipt Result { get; set; }
-    }
-
-    internal class TxReceipt {
-        [JsonProperty("result")] public string Result { get; set; }
-    }
-    
-    public enum TxStatus {
-        Fail = 0,
-        Pass = 1
+    internal class BscTxReceiptSchema : BscResult {
+        [JsonProperty("result")] public BscTxReceipt Result { get; set; }
     }
 }

--- a/BscScanner/Data/BscTxStatus.cs
+++ b/BscScanner/Data/BscTxStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace BscScanner.Data
+{
+    public enum BscTxStatus
+    {
+        Fail = 0,
+        Pass = 1
+    }
+}

--- a/BscScanner/Data/BscValidatorSchema.cs
+++ b/BscScanner/Data/BscValidatorSchema.cs
@@ -2,9 +2,7 @@
 using Newtonsoft.Json;
 
 namespace BscScanner.Data {
-    internal class BscValidatorSchema {
-        [JsonProperty("status")] public string Status { get; set; }
-        [JsonProperty("message")] public string Message { get; set; }
+    internal class BscValidatorSchema : BscResult {
         [JsonProperty("result")] public IEnumerable<BscValidator> Result { get; set; }
     }
 }

--- a/BscScanner/Data/IBscResult.cs
+++ b/BscScanner/Data/IBscResult.cs
@@ -1,0 +1,8 @@
+﻿namespace BscScanner.Data
+{
+    internal interface IBscResult
+    {
+        string Message { get; }
+        string Status { get; }
+    }
+}

--- a/BscScanner/IBscScanClient.cs
+++ b/BscScanner/IBscScanClient.cs
@@ -31,7 +31,7 @@ namespace BscScanner {
 
         #region Transaction
 
-        Task<TxStatus> GetTransactionReceiptStatus(string txHash);
+        Task<BscTxStatus> GetTransactionReceiptStatus(string txHash);
         
         #endregion
 


### PR DESCRIPTION
Added base class to capture status and message for each API call, and implemented basic error handling.
In case of to many requests for the license (free = 5 calls / sec) throws now an HttpRequestException that can be captured by a Poly retry policy. Adapted all unit tests to use a basic retry policy.